### PR TITLE
Fixes issues with supervisord failing

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,11 +124,6 @@ $fromaddress  = '', # Mail from address
 $mail_options = {}, # Hash for mail options
 ```
 
-Note that at least on my Ubuntu test systems, the `supervisor`
-module's execution of `supervisorctl update` fails; this can be fixed
-by manually running that command, letting it do its thing, and then
-re-provisioning.
-
 You will likely want to proxy the Ghost instance using, say,
 `nginx`. The setup of `nginx` is outside the scope of this module.
 
@@ -145,10 +140,6 @@ currently setup custom databases
 permissions of 660 do not allow this. Because the Ghost server creates
 the socket file on each launch, it is impossible to control its
 permissions through Puppet. The best solution to this predicament [(see issue #14)](https://github.com/andschwa/puppet-ghost/issues/14) is to add your web server's user to Ghost's group (e.g. `usermod -a -G ghost www-data`), which will allow it to read the socket.
-
-* If supervisor is not registering the blogs, restarting your system is
-the easiest solution (as always), but you should also try
-`supervisorctrl reread && supervisorctl reload`.
 
 ## Upgrading from 0.2.x
 

--- a/spec/acceptance/blog_spec.rb
+++ b/spec/acceptance/blog_spec.rb
@@ -13,7 +13,7 @@ describe 'ghost class' do
       class {'ghost':}
       ->
       ghost::blog{ 'my_blog':
-        use_supervisor => false,
+        use_supervisor => true,
         socket         => false,
       }
       EOS
@@ -30,5 +30,16 @@ describe 'ghost class' do
     describe command('ls -al /home/ghost/my_blog') do
       its(:stdout) { should match /README.md/ }
     end
+
+    context 'Ghost should be running on the default port' do
+      describe command('sleep 10 && echo "Give Ghost time to start"') do
+        its(:exit_status) { should eq 0 }
+      end
+
+      describe command('curl 0.0.0.0:2368/') do
+        its(:stdout) { should match /Redirecting to https:\/\/my-ghost-blog.com\// }
+      end
+    end
+
   end
 end


### PR DESCRIPTION
* The class was making the ghost user the default user to run the supervisord refresh
* This changes to use root user instead
* Removes note from README.md
* Adds working acceptance test to check supervisord configuration